### PR TITLE
Integrate flipper

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,11 @@ dependencies {
 
     implementation "com.jakewharton.timber:timber:$timberVersion"
 
+    debugImplementation "com.facebook.flipper:flipper:$flipperVersion"
+    debugImplementation "com.facebook.flipper:flipper-network-plugin:$flipperVersion"
+    debugImplementation "com.facebook.soloader:soloader:$soloaderVersion"
+    releaseImplementation "com.facebook.flipper:flipper-noop:$flipperVersion"
+
     testImplementation "androidx.test:core:$testCoreVersion"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttpVersion"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.ishikota.photoviewerandroid">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+
+    <application tools:ignore="GoogleAppIndexingWarning">
+        <activity android:name="com.facebook.flipper.android.diagnostics.FlipperDiagnosticActivity"
+            android:exported="true"/>
+    </application>
+
+</manifest>

--- a/app/src/debug/java/com/ishikota/photoviewerandroid/infra/flipper/FlipperWrapper.kt
+++ b/app/src/debug/java/com/ishikota/photoviewerandroid/infra/flipper/FlipperWrapper.kt
@@ -1,0 +1,31 @@
+package com.ishikota.photoviewerandroid.infra.flipper
+
+import android.content.Context
+import com.facebook.flipper.android.AndroidFlipperClient
+import com.facebook.flipper.android.utils.FlipperUtils
+import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin
+import com.facebook.flipper.plugins.inspector.DescriptorMapping
+import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
+import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
+import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin
+import com.facebook.soloader.SoLoader
+import okhttp3.Interceptor
+
+object FlipperWrapper {
+    private val networkFlipperPlugin = NetworkFlipperPlugin()
+
+    fun initialize(context: Context) {
+        SoLoader.init(context, false)
+        if (FlipperUtils.shouldEnableFlipper(context)) {
+            val client = AndroidFlipperClient.getInstance(context)
+            client.addPlugin(InspectorFlipperPlugin(context, DescriptorMapping.withDefaults()))
+            client.addPlugin(SharedPreferencesFlipperPlugin(context))
+            client.addPlugin(DatabasesFlipperPlugin(context))
+            client.addPlugin(networkFlipperPlugin)
+            client.start()
+        }
+    }
+
+    fun getOkHttpInterceptor(): Interceptor = FlipperOkhttpInterceptor(networkFlipperPlugin)
+}

--- a/app/src/main/java/com/ishikota/photoviewerandroid/PhotoViewerApplication.kt
+++ b/app/src/main/java/com/ishikota/photoviewerandroid/PhotoViewerApplication.kt
@@ -1,6 +1,7 @@
 package com.ishikota.photoviewerandroid
 
 import android.app.Application
+import com.ishikota.photoviewerandroid.infra.flipper.FlipperWrapper
 import com.ishikota.photoviewerandroid.infra.timber.ConsoleDebugTree
 import timber.log.Timber
 
@@ -11,5 +12,6 @@ class PhotoViewerApplication: Application() {
         if (BuildConfig.DEBUG) {
             Timber.plant(ConsoleDebugTree())
         }
+        FlipperWrapper.initialize(this)
     }
 }

--- a/app/src/main/java/com/ishikota/photoviewerandroid/infra/okhttp/OkHttpUtils.kt
+++ b/app/src/main/java/com/ishikota/photoviewerandroid/infra/okhttp/OkHttpUtils.kt
@@ -1,6 +1,7 @@
 package com.ishikota.photoviewerandroid.infra.okhttp
 
 import com.ishikota.photoviewerandroid.BuildConfig
+import com.ishikota.photoviewerandroid.infra.flipper.FlipperWrapper
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 
@@ -11,6 +12,7 @@ fun buildDefaultOkHttpClient(): OkHttpClient = OkHttpClient.Builder().apply {
                 level = HttpLoggingInterceptor.Level.BODY
             }
         )
+        addInterceptor(FlipperWrapper.getOkHttpInterceptor())
     }
 }.build()
 

--- a/app/src/release/java/com/ishikota/photoviewerandroid/infra/flipper/FlipperWrapper.kt
+++ b/app/src/release/java/com/ishikota/photoviewerandroid/infra/flipper/FlipperWrapper.kt
@@ -1,0 +1,17 @@
+package com.ishikota.photoviewerandroid.infra.flipper
+
+import android.content.Context
+import okhttp3.Interceptor
+import okhttp3.Response
+
+object FlipperWrapper {
+
+    fun initialize(context: Context) {
+        // do nothing
+    }
+
+    // just bypass request
+    fun getOkHttpInterceptor() = object: Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response = chain.proceed(chain.request())
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ buildscript {
         truthVersion = '0.42'
         robolectricVersion = '4.2'
         timberVersion = '4.7.1'
+        flipperVersion = '0.30.1'
+        soloaderVersion = '0.6.0'
     }
 
     repositories {


### PR DESCRIPTION
https://fbflipper.com/
Flipper導入

debug build時だけ関連コードを読み込むようにするため、
debug/release用のsrc directoryを作り、
それぞれで同じinterfaceのflipper apiのwrapperを作るようにした。
